### PR TITLE
Add GPT-5.4 and deprecate GPT-5.2

### DIFF
--- a/gat_llm/llm_invoker.py
+++ b/gat_llm/llm_invoker.py
@@ -58,6 +58,7 @@ class LLM_Provider:
         # OpenAI
         "GPT 5 - OpenAI",
         "GPT 5_1 - OpenAI",
+        "GPT 5_2 - OpenAI",
         "GPT 4o - OpenAI",
         "GPT 4.1 - OpenAI",
         "GPT 3.5 - OpenAI",
@@ -107,7 +108,7 @@ class LLM_Provider:
         # Maritaca
         "Sabia3 - Maritaca",
         # OpenAI
-        "GPT 5_2 - OpenAI",
+        "GPT 5_4 - OpenAI",
         "GPT 5 mini - OpenAI",
         "GPT 5 nano - OpenAI",
         # Anthropic
@@ -287,6 +288,8 @@ class LLM_Provider:
         # OpenAI
         elif llm == "GPT 5 - OpenAI":
             return LLM_GPT_OpenAI(model_size="GPT5 OpenAI", reasoning_effort="low")
+        elif llm == "GPT 5_4 - OpenAI":
+            return LLM_GPT_OpenAI(model_size="GPT5_4 OpenAI", reasoning_effort="low")
         elif llm == "GPT 5_2 - OpenAI":
             return LLM_GPT_OpenAI(model_size="GPT5_2 OpenAI", reasoning_effort="low")
         elif llm == "GPT 5_1 - OpenAI":

--- a/gat_llm/llm_providers/openai.py
+++ b/gat_llm/llm_providers/openai.py
@@ -27,6 +27,13 @@ class LLM_GPT_OpenAI(LLM_Service):
             )
             self.price_per_M_input_tokens = 1.25
             self.price_per_M_output_tokens = 10
+        elif model_size == "GPT5_4 OpenAI":
+            self.model_id = "gpt-5.4"
+            self.llm_description = (
+                "OpenAI GPT5.4 (Large-size LLM) - directly from OpenAI"
+            )
+            self.price_per_M_input_tokens = 2.5
+            self.price_per_M_output_tokens = 15
         elif model_size == "GPT5_2 OpenAI":
             self.model_id = "gpt-5.2"
             self.llm_description = (


### PR DESCRIPTION
## Summary
- Add GPT-5.4 to the active model pool with pricing from OpenAI docs ($2.50/M input, $15.00/M output)
- Deprecate GPT-5.2, moving it from `allowed_llms` to `deprecated_llms`

## Test plan
- [x] Verified `pytest tests/test_llm_interface.py` passes
- [x] Manual test with GPT-5.4 API calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)